### PR TITLE
Added the characters '+' and '/' to the list of possible characters

### DIFF
--- a/lyft_rides/request.py
+++ b/lyft_rides/request.py
@@ -173,7 +173,7 @@ class Request(object):
         if token_type not in http.VALID_TOKEN_TYPES:
             return False
 
-        allowed_chars = ascii_letters + digits + '_' + '-' + '=='
+        allowed_chars = ascii_letters + digits + '_' + '-' + '==' + '+' + '/'
 
         # True if token only contains allowed_chars
         return all(characters in allowed_chars for characters in token)


### PR DESCRIPTION
Seems that an access token can contain / and + on it and the method throws false even though it shouldn't. Fixes #2